### PR TITLE
Fix Typekit URLs to use HTTPS scheme

### DIFF
--- a/js/adobe-caslon-pro.gz.js
+++ b/js/adobe-caslon-pro.gz.js
@@ -1,1 +1,1 @@
-document.write('<script src="//use.typekit.net/qhv3iqj.js"><\/script>');
+document.write('<script src="https://use.typekit.net/qhv3iqj.js"><\/script>');

--- a/js/base-fonts.gz.js
+++ b/js/base-fonts.gz.js
@@ -1,1 +1,1 @@
-document.write('<script src="//use.typekit.net/onz5gap.js"><\/script>');
+document.write('<script src="https://use.typekit.net/onz5gap.js"><\/script>');


### PR DESCRIPTION
## Summary
- Replace protocol-relative Typekit script URLs with explicit HTTPS

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e720a2198832b948806fbdfdddd88